### PR TITLE
SEO: Add branded headers and cross-links to README and project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Toast Image Editor
+> Part of [DXPR CMS](https://dxpr.com/c/marketing-cms) -- The AI-Powered Drupal CMS
+>
+> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+
+# Toast Image Editor -- Professional Drupal Image Editing with Revision Support
 
 Professional image editing capabilities for Drupal media with revision
 support and offline compatibility.
@@ -136,3 +140,9 @@ docker compose run --rm drupal-check
 - [Image Widget Crop](https://www.drupal.org/project/image_widget_crop) - Crop-only functionality
 - [Focal Point](https://www.drupal.org/project/focal_point) - Smart image cropping
 - [ImageMagick](https://www.drupal.org/project/imagemagick) - Server-side image processing
+
+## Related DXPR Modules
+
+- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) -- Drag-and-drop Drupal page builder
+- [AI Image Alt Text](https://www.drupal.org/project/ai_image_alt_text) -- AI-generated alt text for Drupal images
+- [CKEditor AI Agent](https://www.drupal.org/project/ckeditor_ai_agent) -- AI-powered content creation in the Drupal editor

--- a/README.md
+++ b/README.md
@@ -148,8 +148,7 @@ docker compose run --rm drupal-check
 
 ## Related Modules
 
-- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) - Drag-and-drop Drupal page builder
-- [AI Image Alt Text](https://www.drupal.org/project/ai_image_alt_text) - AI-generated alt text for Drupal images
-- [CKEditor AI Agent](https://www.drupal.org/project/ckeditor_ai_agent) - AI-powered content creation in the Drupal editor
-- [Crop](https://www.drupal.org/project/crop) - Crop API for reusable crop types in Drupal
-- [Focal Point](https://www.drupal.org/project/focal_point) - Smart image cropping based on focal point selection
+- [Media](https://www.drupal.org/project/drupal) - Required core module; the editor attaches to media edit forms and creates media revisions on save
+- [File](https://www.drupal.org/project/drupal) - Required core module used for file entity storage, URI handling, and file system writes
+- [Image](https://www.drupal.org/project/drupal) - Core module used to flush image style derivatives when an edited image is saved
+- [AI Image Alt Text](https://www.drupal.org/project/ai_image_alt_text) - Generate accessible alt text with AI after editing images

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-> Part of [DXPR CMS](https://dxpr.com/c/marketing-cms) -- The AI-Powered Drupal CMS
+> **Toast Image Editor** is a Drupal module by [DXPR](https://dxpr.com) that
+> brings professional image editing capabilities into Drupal's media library
+> using Toast UI Image Editor, supporting crop, rotate, draw, filter, and text
+> overlay. By [DXPR](https://dxpr.com).
 >
-> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+> [Getting Started](https://dxpr.com/c/getting-started) |
+> [Pricing](https://dxpr.com/pricing) |
+> [Try Free Demo](https://dxpr.com/try)
 
-# Toast Image Editor -- Professional Drupal Image Editing with Revision Support
+# Toast Image Editor - Professional Drupal Image Editing with Revision Support
 
 Professional image editing capabilities for Drupal media with revision
 support and offline compatibility.
@@ -141,8 +146,10 @@ docker compose run --rm drupal-check
 - [Focal Point](https://www.drupal.org/project/focal_point) - Smart image cropping
 - [ImageMagick](https://www.drupal.org/project/imagemagick) - Server-side image processing
 
-## Related DXPR Modules
+## Related Modules
 
-- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) -- Drag-and-drop Drupal page builder
-- [AI Image Alt Text](https://www.drupal.org/project/ai_image_alt_text) -- AI-generated alt text for Drupal images
-- [CKEditor AI Agent](https://www.drupal.org/project/ckeditor_ai_agent) -- AI-powered content creation in the Drupal editor
+- [DXPR Builder](https://www.drupal.org/project/dxpr_builder) - Drag-and-drop Drupal page builder
+- [AI Image Alt Text](https://www.drupal.org/project/ai_image_alt_text) - AI-generated alt text for Drupal images
+- [CKEditor AI Agent](https://www.drupal.org/project/ckeditor_ai_agent) - AI-powered content creation in the Drupal editor
+- [Crop](https://www.drupal.org/project/crop) - Crop API for reusable crop types in Drupal
+- [Focal Point](https://www.drupal.org/project/focal_point) - Smart image cropping based on focal point selection

--- a/docs/toast_image_editor_project_desc.html
+++ b/docs/toast_image_editor_project_desc.html
@@ -86,11 +86,11 @@
 
 <h3>Related Modules</h3>
 <ul>
-<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> - Drag-and-drop Drupal page builder</li>
-<li><a href="https://www.drupal.org/project/ai_image_alt_text">AI Image Alt Text</a> - AI-generated alt text for Drupal images</li>
-<li><a href="https://www.drupal.org/project/ckeditor_ai_agent">CKEditor AI Agent</a> - AI-powered content creation in the Drupal editor</li>
-<li><a href="https://www.drupal.org/project/crop">Crop API</a> - image cropping framework</li>
-<li><a href="https://www.drupal.org/project/focal_point">Focal Point</a> - focal point image cropping</li>
+<li><a href="https://www.drupal.org/project/ai_image_alt_text">AI Image Alt Text</a> - Generate accessible alt text with AI after editing images</li>
+<li><a href="https://www.drupal.org/project/image_widget_crop">Image Widget Crop</a> - Provides crop-only functionality for image fields, complementing Toast's full editing suite</li>
+<li><a href="https://www.drupal.org/project/focal_point">Focal Point</a> - Smart focal-point cropping for responsive image styles; pairs well with Toast for manual edits</li>
 </ul>
+
+<p>Toast Image Editor is part of <a href="https://dxpr.com/c/marketing-cms">DXPR's marketing CMS platform</a>, which brings browser-based image editing, AI-powered content tools, and streamlined media workflows together for Drupal teams.</p>
 
 <p><strong>Toast Image Editor</strong> provides a complete image editing suite within your browser, combining the power of desktop software with the convenience of web-based editing, all while maintaining Drupal's revision control and security standards.</p>

--- a/docs/toast_image_editor_project_desc.html
+++ b/docs/toast_image_editor_project_desc.html
@@ -1,5 +1,3 @@
-<p><strong>Part of the <a href="https://dxpr.com/c/marketing-cms">DXPR CMS</a> ecosystem</strong> -- the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
-
 <p>This module is included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <blockquote>
@@ -86,11 +84,13 @@
   </p>
 </div>
 
-<h3>Related DXPR Modules</h3>
+<h3>Related Modules</h3>
 <ul>
-<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> -- Drag-and-drop Drupal page builder</li>
-<li><a href="https://www.drupal.org/project/ai_image_alt_text">AI Image Alt Text</a> -- AI-generated alt text for Drupal images</li>
-<li><a href="https://www.drupal.org/project/ckeditor_ai_agent">CKEditor AI Agent</a> -- AI-powered content creation in the Drupal editor</li>
+<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> - Drag-and-drop Drupal page builder</li>
+<li><a href="https://www.drupal.org/project/ai_image_alt_text">AI Image Alt Text</a> - AI-generated alt text for Drupal images</li>
+<li><a href="https://www.drupal.org/project/ckeditor_ai_agent">CKEditor AI Agent</a> - AI-powered content creation in the Drupal editor</li>
+<li><a href="https://www.drupal.org/project/crop">Crop API</a> - image cropping framework</li>
+<li><a href="https://www.drupal.org/project/focal_point">Focal Point</a> - focal point image cropping</li>
 </ul>
 
 <p><strong>Toast Image Editor</strong> provides a complete image editing suite within your browser, combining the power of desktop software with the convenience of web-based editing, all while maintaining Drupal's revision control and security standards.</p>

--- a/docs/toast_image_editor_project_desc.html
+++ b/docs/toast_image_editor_project_desc.html
@@ -1,3 +1,5 @@
+<p><strong>Part of the <a href="https://dxpr.com/c/marketing-cms">DXPR CMS</a> ecosystem</strong> -- the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
+
 <p>This module is included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <blockquote>
@@ -83,5 +85,12 @@
     <a href="https://try.dxpr.com/" class="action-button">View Demo</a>
   </p>
 </div>
+
+<h3>Related DXPR Modules</h3>
+<ul>
+<li><a href="https://www.drupal.org/project/dxpr_builder">DXPR Builder</a> -- Drag-and-drop Drupal page builder</li>
+<li><a href="https://www.drupal.org/project/ai_image_alt_text">AI Image Alt Text</a> -- AI-generated alt text for Drupal images</li>
+<li><a href="https://www.drupal.org/project/ckeditor_ai_agent">CKEditor AI Agent</a> -- AI-powered content creation in the Drupal editor</li>
+</ul>
 
 <p><strong>Toast Image Editor</strong> provides a complete image editing suite within your browser, combining the power of desktop software with the convenience of web-based editing, all while maintaining Drupal's revision control and security standards.</p>


### PR DESCRIPTION
## Summary
- Added branded DXPR CMS header with links to dxpr.com product pages at the top of README.md and desc.html
- Improved H1 title with descriptive, keyword-rich suffix for better search visibility
- Added Related DXPR Modules section with cross-links to DXPR Builder, AI Image Alt Text, and CKEditor AI Agent

## SEO Impact
- Improved keyword targeting: "Professional Drupal Image Editing with Revision Support" in H1
- Cross-linking to sibling modules strengthens internal link structure on drupal.org
- Branded header increases DXPR CMS discoverability from module pages
- Consistent branding across the DXPR module ecosystem